### PR TITLE
Making possible to call deferred() with array

### DIFF
--- a/lib/deferred.js
+++ b/lib/deferred.js
@@ -129,11 +129,11 @@ Deferred.prototype = {
 module.exports = createDeferred = function (value) {
 	var l, d, waiting, initialized, result, promise;
 	if ((l = arguments.length)) {
-		if (l > 1) {
+		if (l > 1 || Array.isArray(value)) {
 			d = new Deferred();
 			waiting = 0;
 			result = new Array(l);
-			every.call(arguments, function (value, index) {
+			every.call(Array.isArray(value) ? value : arguments, function (value, index) {
 				if (isPromise(value)) {
 					++waiting;
 					value.end(function (value) {


### PR DESCRIPTION
Hi,
Untill now when i had an array of promises, to group them I would just do
deferred.apply(deferred, arrayOfPromises).then( ok, fail );

That worked grate for me, untill I had to make some background job that would do some housekeeping on my mongodb collection, at some point it had to update 175K objects,
each update was a promise and I wanted to combine them with the above aproach, but then i got from node:

RangeError: Maximum call stack size exceeded

The commited minor change seems to be working with my use case. =)
Is there a better approach?
