### PR TITLE
Add kew to benchmarks

### DIFF
--- a/benchmark/concurrent.js
+++ b/benchmark/concurrent.js
@@ -106,7 +106,7 @@ tests = [function () {
 	};
 
 	self = function () {
-		dlstat(__filename).fin(function () {
+		dlstat(__filename).then(function () {
 			if (!--i) {
 				data["kew: Dedicated wrapper"] = now() - time;
 				// Get out of try/catch clause

--- a/benchmark/one-after-another.js
+++ b/benchmark/one-after-another.js
@@ -96,7 +96,7 @@ tests = [function () {
 	};
 
 	self = function () {
-		dlstat(__filename).fin(function (stats) {
+		dlstat(__filename).then(function (stats) {
 			if (--i) {
 				self(stats);
 			} else {


### PR DESCRIPTION
Results on my machine:

```
Promise overhead (concurrent calls) x10000:

1:   278ms  Base (plain Node.js lstat call)
2:   283ms  kew: Dedicated wrapper
3:   410ms  Deferred: Dedicated wrapper
4:   496ms  When: Dedicated wrapper
5:   499ms  Deferred: Promisify (generic wrapper)
6:   542ms  Deferred: Map + Promisify
7:   969ms  Q: Dedicated wrapper
8:  1265ms  jQuery.Deferred: Dedicated wrapper
9:  1761ms  Q: nbind (generic wrapper)
```

and

```
Promise overhead (calling one after another) x10000:

1:   338ms  kew: Dedicated wrapper
2:   371ms  Base (plain Node.js lstat call)
3:   523ms  When: Dedicated wrapper
4:   537ms  Deferred: Dedicated wrapper
5:   598ms  Deferred: Promisify (generic wrapper)
6:   612ms  jQuery.Deferred: Dedicated wrapper
7:   867ms  Q: Dedicated wrapper
8:  1240ms  Q: nbind (generic wrapper)
```
